### PR TITLE
optional allow blacklist to be password protected

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -78,6 +78,8 @@ nginx_redirects_for_browser_profile_and_locale_enabled: no
 nginx_php_virtual_context_path: ''
 
 nginx_php_path_blacklist_enabled: no
+nginx_php_path_blacklist_with_password: no
+nginx_php_path_blacklist_with_password_auth_location: /data/www/auth
 nginx_php_path_blacklist_regexp: /static
 nginx_php_path_blacklist_try_files: '$uri $uri/'
 nginx_php_append_querystring: ''

--- a/templates/etc/nginx/sites-available/site.conf
+++ b/templates/etc/nginx/sites-available/site.conf
@@ -171,7 +171,18 @@ server {
 {% if nginx_php_enabled %}
 {% if nginx_php_path_blacklist_enabled %}
   location ~ {{ nginx_php_path_blacklist_regexp }} {
+{%   if nginx_php_path_blacklist_with_password %}
+    auth_basic "Private";
+    auth_basic_user_file {{ nginx_php_path_blacklist_with_password_auth_location }};
+
+    fastcgi_pass unix:{{ runtime_root }}/php/fpm.sock;
+    fastcgi_index index.php;
+    fastcgi_buffers 8 {{ nginx_fastcgi_buffers }};
+    fastcgi_buffer_size {{ nginx_fastcgi_buffers }};
+    include /etc/nginx/fastcgi_params;
+{%   else %}
     try_files /{{ nginx_php_path_blacklist_try_files }} =404;
+{%   endif %}
   }
 {% endif %}
 


### PR DESCRIPTION
Previously only could blacklist via 404, now optionally allows for password protecting the blacklist instead.  To set the password simply define `nginx_auth_password` in a vault and it will generate.