### PR TITLE
nginx_creates_docroot allows you to make your own docroot

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Tunables
 * `nginx_performance_tuning_enabled` (boolean) - Aggressively favour performance over compatibility?
 * `nginx_file_descriptor_caching_enabled` (boolean) - Enable file descriptor caching?
 * `nginx_docroot` (string) - Directory for docroot
+* `nginx_creates_docroot` (boolean) - Enable to get nginx to create the docroot path
 * `nginx_standard_configuration` (boolean) - Using included configuration?
 * `nginx_passenger_enabled` (boolean) - Enable passenger for Ruby apps?
 * `nginx_php_enabled` (boolean) - Pass requests for PHP files to php-fpm?

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,6 +28,7 @@ nginx_performance_tuning_enabled: no
 nginx_file_descriptor_caching_enabled: no
 
 nginx_docroot: /data/www/docroot
+nginx_creates_docroot: yes
 
 nginx_standard_configuration: yes
 nginx_passenger_enabled: no

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -32,6 +32,7 @@
     owner: "{{ nginx_user }}"
     group: wcadmin
     mode: 0775
+  when: nginx_creates_docroot
   tags:
     - directory-structure
     - nginx


### PR DESCRIPTION
If you wanted to create your docroot at `/data/www/docroot/public` and deploy your code to `/data/www/docroot`, git clone would complain that it's a non-empty directory. Things should probably be designed so that this isn't an issue but it's not unreasonable to support projects where it is.