### PR TITLE
added when param for uploading auth files

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -82,6 +82,7 @@
     group: wcadmin
     mode: 0664
   notify: Reload Service | nginx
+  when: nginx_auth_enabled
   tags:
     - configuration
     - nginx


### PR DESCRIPTION
Only upload when nginx_auth_enabled

Bug introduced in commit 71ed2fc5ebfa1f0fb2290c2113d60ed3461d5675