### PR TITLE
Revert "nginx_ssl_enforce redirects traffic"

### DIFF
--- a/templates/etc/nginx/sites-available/site.conf
+++ b/templates/etc/nginx/sites-available/site.conf
@@ -25,13 +25,6 @@ server {
 }
 
 {% endif %}
-{% if nginx_ssl_enforced %}
-server {
-  listen 80;
-  return 302 https://$host$request_uri;
-}
-
-{% endif %}
 server {
 {% if nginx_developer_environments_enabled %}
   server_name ~{{ nginx_developer_environment_regexp }};


### PR DESCRIPTION
Reverts telusdigital/ansible-nginx#15

USS only listen on port 80 and the ELB handles the SSL cert
443 > ELB > 80
the nginx_ssl_enforced tells nginx to look for the x-forwarded-proto from ELB to see if the request came through HTTPS or HTTP