### PR TITLE
Enablding SSL detection by default

### DIFF
--- a/templates/etc/nginx/sites-available/standard-configuration.conf
+++ b/templates/etc/nginx/sites-available/standard-configuration.conf
@@ -68,7 +68,6 @@ server {
 {% endif %}
 {% endif %}
 
-{% if nginx_ssl_enabled %}
   ###
   # SSL Detection
   ###
@@ -82,7 +81,6 @@ server {
   if ( $https = 'on' ) {
     set $ssl_enabled true;
   }
-{% endif %}
 
 {% if nginx_ssl_enforced %}
   ###


### PR DESCRIPTION
Here's the scenario, there's two flags in this nginx package for enabling SSL. `nginx_ssl_enabled` and `nginx_ssl_enforced`. When you have `nginx_ssl_enforced` without `nginx_ssl_enabled` it will throw out an error that says 

```
NOTIFIED: [telusdigital.nginx | Reload Service | nginx] *********************** 
failed: [localhost] => {"failed": true}
msg: nginx: [emerg] unknown "ssl_enabled" variable
nginx: configuration file /etc/nginx/nginx.conf test failed
```

This is because the code on line [92](https://github.com/telusdigital/ansible-nginx/blob/master/templates/etc/nginx/sites-available/standard-configuration.conf#L92) is parsed, but `ssl_enabled` was never set in lines [71-85](https://github.com/telusdigital/ansible-nginx/blob/master/templates/etc/nginx/sites-available/standard-configuration.conf#L71-L85) .

What I am proposing to do is enabled the code in lines 71-85 by default so that we don't run into this issue again. The code in that line is only for detection, and should work in any scenario. 

@telusdigital/guild-devops plz review :cool:
