### PR TITLE
Disabling HTTP2 when SSL is not enabled

### DIFF
--- a/templates/etc/nginx/sites-available/standard-configuration.conf
+++ b/templates/etc/nginx/sites-available/standard-configuration.conf
@@ -20,7 +20,7 @@ map $http_x_forwarded_for $x_forwarded_for_in_whitelist {
 
 {% if nginx_ssl_disabled %}
 server {
-  listen {{ nginx_ssl_port }}{% if nginx_http2_enabled %} http2{% endif %};
+  listen {{ nginx_ssl_port }};
   return 301 http://$host$request_uri;
 }
 


### PR DESCRIPTION
Most browsers do not support http2 on a non-ssl connection.

See here: http://caniuse.com/#feat=http2