### PR TITLE
Making sure auth isn't enabled by default

### DIFF
--- a/test/integration/default/serverspec/localhost/default_spec.rb
+++ b/test/integration/default/serverspec/localhost/default_spec.rb
@@ -14,6 +14,12 @@ end
 
 describe 'ansible-nginx::configure' do
 
+  # should not need bool() on vars
+  # testing that this doesn't get created by default
+  describe file('/data/www/auth') do
+    it { should_not be_a_file }
+  end
+
   describe file('/var/run/nginx') do
     it { should be_directory }
     it { should be_owned_by 'www-data' }


### PR DESCRIPTION
`/data/www/auth` shouldn't be created by default because we have `nginx_auth_enabled` set to no by default.