### PR TITLE
New tuneable required for our Prepaid app.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Tunables
 * `nginx_auth_salt` (string) - Salt for auth password?
 * `nginx_fastcgi_buffers` (string) - Buffer size for FastCGI requests
 * `nginx_context_proxy_enabled` (boolean) - Proxy requests for specific context paths?
+* `nginx_context_proxy_pass_location_try_files_override` (boolean) - Disable default location try_files if proxy context_path conflicts?
 * `nginx_context_proxy_host` (string) - Upstream location for proxied requests
 * `nginx_context_proxy_domain_equivalence` (string) - Rewrite cookies for one domain to another, with proxied requests.
 * `nginx_context_proxy_paths` (list) - Paths that should be proxied

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -69,6 +69,7 @@ nginx_auth_salt: apr1
 nginx_fastcgi_buffers: 8k
 
 nginx_context_proxy_enabled: no
+nginx_context_proxy_pass_location_try_files_override: no
 nginx_context_proxy_host: 'http://www.telus.com'
 nginx_context_proxy_domain_equivalence: "telus.com {{ domain }}"
 nginx_context_proxy_paths:
@@ -99,7 +100,7 @@ nginx_php_fastcgi_param_extras: []
 nginx_php_index_only: no
 
 nginx_static_asset_handling_enabled: yes
-nginx_static_asset_handling_extentions: 
+nginx_static_asset_handling_extentions:
   - ico
   - css
   - js

--- a/templates/etc/nginx/sites-available/standard-configuration.conf
+++ b/templates/etc/nginx/sites-available/standard-configuration.conf
@@ -305,9 +305,11 @@ server {
 {% endif %}
   }
 {% else %}
-  location / {
-    try_files $uri $uri/ /index.html;
-  }
+  {% if not nginx_context_proxy_pass_location_try_files_override %}
+    location / {
+      try_files $uri $uri/ /index.html;
+    }
+  {% endif %}
 {% endif %}
 
 {% if nginx_prerender_enabled %}


### PR DESCRIPTION
We want to setup nginx with a reverse proxy pass setup such that port 80 > 9000:
E.g.
```
location / {
    proxy_pass http://localhost:9000/
}
```

Our problem was that when PHP is not enabled, by default, the current standard configuration dumps the following near the end of the standard configuration (site.conf):

```
location / {
      try_files $uri $uri/ /index.html;
}
```

...and with our setup this results in nginx complaining that there are 2 location configuration blocks at the same location(both configured at `location /`). We're proposing to get around this by setting this new tuneable (defaults to no) called:

```
nginx_context_proxy_pass_location_try_files_override
```

When set to `yes`, this will not output the default into the site.conf:

```
location / {
      try_files $uri $uri/ /index.html;
}
```