### PR TITLE
Updated nginx testing and init script

### DIFF
--- a/files/etc/init.d/nginx
+++ b/files/etc/init.d/nginx
@@ -48,14 +48,14 @@ case "$1" in
                         # Set the ulimits
                         ulimit $ULIMIT
                 fi
-                start-stop-daemon --start --quiet --pidfile /data/run/nginx/nginx.pid \
+                start-stop-daemon --start --quiet --pidfile "{{ nginx_pidfile_path }}" \
                     --exec $DAEMON -- $DAEMON_OPTS || true
                 echo "$NAME."
                 ;;
 
         stop)
                 echo -n "Stopping $DESC: "
-                start-stop-daemon --stop --quiet --pidfile /data/run/nginx/nginx.pid \
+                start-stop-daemon --stop --quiet --pidfile "{{ nginx_pidfile_path }}" \
                     --exec $DAEMON || true
                 echo "$NAME."
                 ;;
@@ -67,7 +67,7 @@ case "$1" in
                     exit 0
                 fi
                 start-stop-daemon --stop --quiet --pidfile \
-                    /data/run/nginx/nginx.pid --exec $DAEMON || true
+                    "{{ nginx_pidfile_path }}" --exec $DAEMON || true
                 sleep 1
                 test_nginx_config
                 # Check if the ULIMIT is set in /etc/default/nginx
@@ -76,7 +76,7 @@ case "$1" in
                         ulimit $ULIMIT
                 fi
                 start-stop-daemon --start --quiet --pidfile \
-                    /data/run/nginx/nginx.pid --exec $DAEMON -- $DAEMON_OPTS || true
+                    "{{ nginx_pidfile_path }}" --exec $DAEMON -- $DAEMON_OPTS || true
                 echo "$NAME."
                 ;;
 
@@ -86,7 +86,7 @@ case "$1" in
                     log_end_msg 1 # Configuration error
                     exit 0
                 fi
-                start-stop-daemon --stop --signal HUP --quiet --pidfile /data/run/nginx/nginx.pid \
+                start-stop-daemon --stop --signal HUP --quiet --pidfile "{{ nginx_pidfile_path }}" \
                     --exec $DAEMON || true
                 echo "$NAME."
                 ;;
@@ -101,7 +101,7 @@ case "$1" in
                 ;;
 
         status)
-                status_of_proc -p /data/run/nginx/nginx.pid "$DAEMON" nginx && exit 0 || exit $?
+                status_of_proc -p "{{ nginx_pidfile_path }}" "$DAEMON" nginx && exit 0 || exit $?
                 ;;
         *)
                 echo "Usage: $NAME {start|stop|restart|reload|force-reload|status|configtest}" >&2

--- a/files/etc/init.d/nginx
+++ b/files/etc/init.d/nginx
@@ -48,14 +48,14 @@ case "$1" in
                         # Set the ulimits
                         ulimit $ULIMIT
                 fi
-                start-stop-daemon --start --quiet --pidfile /var/run/nginx/nginx.pid \
+                start-stop-daemon --start --quiet --pidfile /data/run/nginx/nginx.pid \
                     --exec $DAEMON -- $DAEMON_OPTS || true
                 echo "$NAME."
                 ;;
 
         stop)
                 echo -n "Stopping $DESC: "
-                start-stop-daemon --stop --quiet --pidfile /var/run/nginx/nginx.pid \
+                start-stop-daemon --stop --quiet --pidfile /data/run/nginx/nginx.pid \
                     --exec $DAEMON || true
                 echo "$NAME."
                 ;;
@@ -67,7 +67,7 @@ case "$1" in
                     exit 0
                 fi
                 start-stop-daemon --stop --quiet --pidfile \
-                    /var/run/nginx/nginx.pid --exec $DAEMON || true
+                    /data/run/nginx/nginx.pid --exec $DAEMON || true
                 sleep 1
                 test_nginx_config
                 # Check if the ULIMIT is set in /etc/default/nginx
@@ -76,7 +76,7 @@ case "$1" in
                         ulimit $ULIMIT
                 fi
                 start-stop-daemon --start --quiet --pidfile \
-                    /var/run/nginx/nginx.pid --exec $DAEMON -- $DAEMON_OPTS || true
+                    /data/run/nginx/nginx.pid --exec $DAEMON -- $DAEMON_OPTS || true
                 echo "$NAME."
                 ;;
 
@@ -86,7 +86,7 @@ case "$1" in
                     log_end_msg 1 # Configuration error
                     exit 0
                 fi
-                start-stop-daemon --stop --signal HUP --quiet --pidfile /var/run/nginx/nginx.pid \
+                start-stop-daemon --stop --signal HUP --quiet --pidfile /data/run/nginx/nginx.pid \
                     --exec $DAEMON || true
                 echo "$NAME."
                 ;;
@@ -101,7 +101,7 @@ case "$1" in
                 ;;
 
         status)
-                status_of_proc -p /var/run/nginx/nginx.pid "$DAEMON" nginx && exit 0 || exit $?
+                status_of_proc -p /data/run/nginx/nginx.pid "$DAEMON" nginx && exit 0 || exit $?
                 ;;
         *)
                 echo "Usage: $NAME {start|stop|restart|reload|force-reload|status|configtest}" >&2

--- a/test/integration/default/serverspec/localhost/default_spec.rb
+++ b/test/integration/default/serverspec/localhost/default_spec.rb
@@ -20,18 +20,18 @@ describe 'ansible-nginx::configure' do
     it { should_not be_a_file }
   end
 
-  describe file('/var/run/nginx') do
+  describe file('/data/run/nginx') do
     it { should be_directory }
     it { should be_owned_by 'www-data' }
     it { should be_grouped_into 'www-data' }
   end
 
   describe file('/etc/init.d/nginx') do
-    its(:content) { should match /\/var\/run\/nginx\/nginx.pid/ }
+    its(:content) { should match /\/data\/run\/nginx\/nginx.pid/ }
   end
 
   describe file('/etc/logrotate.d/nginx') do
-    its(:content) { should match /\/var\/run\/nginx\/nginx.pid/ }
+    its(:content) { should match /\/data\/run\/nginx\/nginx.pid/ }
   end
 
   describe file('/etc/default/nginx') do
@@ -40,7 +40,7 @@ describe 'ansible-nginx::configure' do
 
   describe file('/etc/nginx/nginx.conf') do
     its(:content) { should match /user www-data;/ }
-    its(:content) { should match /pid \/var\/run\/nginx\/nginx.pid;/ }
+    its(:content) { should match /pid \/data\/run\/nginx\/nginx.pid;/ }
     its(:content) { should match /worker_connections 4096;/ }
     its(:content) { should match /server_tokens off;/ }
     its(:content) { should match /header field./ }

--- a/test/integration/password-protect/serverspec/localhost/default_spec.rb
+++ b/test/integration/password-protect/serverspec/localhost/default_spec.rb
@@ -17,18 +17,18 @@ describe 'ansible-nginx::configure' do
     it { should be_a_file }
   end
 
-  describe file('/var/run/nginx') do
+  describe file('/data/run/nginx') do
     it { should be_directory }
     it { should be_owned_by 'www-data' }
     it { should be_grouped_into 'www-data' }
   end
 
   describe file('/etc/init.d/nginx') do
-    its(:content) { should match /\/var\/run\/nginx\/nginx.pid/ }
+    its(:content) { should match /\/data\/run\/nginx\/nginx.pid/ }
   end
 
   describe file('/etc/logrotate.d/nginx') do
-    its(:content) { should match /\/var\/run\/nginx\/nginx.pid/ }
+    its(:content) { should match /\/data\/run\/nginx\/nginx.pid/ }
   end
 
   describe file('/etc/default/nginx') do
@@ -37,7 +37,7 @@ describe 'ansible-nginx::configure' do
 
   describe file('/etc/nginx/nginx.conf') do
     its(:content) { should match /user www-data;/ }
-    its(:content) { should match /pid \/var\/run\/nginx\/nginx.pid;/ }
+    its(:content) { should match /pid \/data\/run\/nginx\/nginx.pid;/ }
     its(:content) { should match /worker_connections 4096;/ }
     its(:content) { should match /server_tokens off;/ }
     its(:content) { should match /header field./ }


### PR DESCRIPTION
Current iteration results in the following error on a fresh server build and reforge.
`
t882343@application-i0c97f9f3bc2148403-mytelus-staging:/data/www$ sudo service nginx restart
Restarting nginx: nginx: [emerg] bind() to 0.0.0.0:81 failed (98: Address already in use)
nginx: [emerg] bind() to 0.0.0.0:80 failed (98: Address already in use)
nginx: [emerg] bind() to 0.0.0.0:81 failed (98: Address already in use)
nginx: [emerg] bind() to 0.0.0.0:80 failed (98: Address already in use)
nginx: [emerg] bind() to 0.0.0.0:81 failed (98: Address already in use)
nginx: [emerg] bind() to 0.0.0.0:80 failed (98: Address already in use)
nginx: [emerg] bind() to 0.0.0.0:81 failed (98: Address already in use)
nginx: [emerg] bind() to 0.0.0.0:80 failed (98: Address already in use)
nginx: [emerg] bind() to 0.0.0.0:81 failed (98: Address already in use)
nginx: [emerg] bind() to 0.0.0.0:80 failed (98: Address already in use)
nginx: [emerg] still could not bind()
`
So I corrected the test and location of the pidfile.