### PR TITLE
add nginx_fastcgi_buffer_size variable - IO-668

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -67,7 +67,8 @@ nginx_auth_location: /data/www/auth
 nginx_auth_username: digital
 nginx_auth_salt: apr1
 
-nginx_fastcgi_buffers: 8k
+nginx_fastcgi_buffers: '8 8k'
+nginx_fastcgi_buffer_size: 8k
 
 nginx_context_proxy_enabled: no
 nginx_context_proxy_pass_location_try_files_override: no

--- a/templates/etc/nginx/sites-available/standard-configuration.conf
+++ b/templates/etc/nginx/sites-available/standard-configuration.conf
@@ -261,8 +261,8 @@ server {
 {% endif %}
     fastcgi_pass unix:{{ php_fpm_socket_path }};
     fastcgi_index index.php;
-    fastcgi_buffers 8 {{ nginx_fastcgi_buffers }};
-    fastcgi_buffer_size {{ nginx_fastcgi_buffers }};
+    fastcgi_buffers {{ nginx_fastcgi_buffers }};
+    fastcgi_buffer_size {{ nginx_fastcgi_buffer_size }};
     include /etc/nginx/fastcgi_params;
 {%   else %}
     try_files /{{ nginx_php_path_blacklist_try_files }} =404;
@@ -338,8 +338,8 @@ server {
 {% endif %}
       fastcgi_pass unix:{{ php_fpm_socket_path }};
       fastcgi_index index.php;
-      fastcgi_buffers 8 {{ nginx_fastcgi_buffers }};
-      fastcgi_buffer_size {{ nginx_fastcgi_buffers }};
+      fastcgi_buffers {{ nginx_fastcgi_buffers }};
+      fastcgi_buffer_size {{ nginx_fastcgi_buffer_size }};
       include /etc/nginx/fastcgi_params;
 {%   if nginx_php_fastcgi_param_extras %}
 {%     for parameter in nginx_php_fastcgi_param_extras %}
@@ -368,8 +368,8 @@ server {
 {% endif %}
     fastcgi_pass unix:{{ php_fpm_socket_path }};
     fastcgi_index index.php;
-    fastcgi_buffers 8 {{ nginx_fastcgi_buffers }};
-    fastcgi_buffer_size {{ nginx_fastcgi_buffers }};
+    fastcgi_buffers {{ nginx_fastcgi_buffers }};
+    fastcgi_buffer_size {{ nginx_fastcgi_buffer_size }};
     include /etc/nginx/fastcgi_params;
 {%   if nginx_php_fastcgi_param_extras %}
 {%     for parameter in nginx_php_fastcgi_param_extras %}


### PR DESCRIPTION
to fix the error "upstream sent too big header while reading response header from upstream":
fastcgi_buffers 16 16k; 
fastcgi_buffer_size 32k;
